### PR TITLE
ci: exclude aiohttp updates check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    ignore:
+      # Ignore updates for aiohttp as v3 needs asyncio tests
+      - dependency-name: "aiohttp"


### PR DESCRIPTION
Ignore updates for `aiohttp` as v3 needs asyncio tests