### PR TITLE
feat: add intraday response models

### DIFF
--- a/openapi/fitbit-web-api-openapi-fixed.json
+++ b/openapi/fitbit-web-api-openapi-fixed.json
@@ -463,7 +463,13 @@
         "responses": {
           "200": {
             "description": "A successful request.",
-            "content": {}
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetAzmIntradayResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "The request had bad syntax or was inherently impossible to be satified.",
@@ -534,7 +540,13 @@
         "responses": {
           "200": {
             "description": "A successful request.",
-            "content": {}
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetAzmIntradayResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "The request had bad syntax or was inherently impossible to be satified.",
@@ -597,7 +609,13 @@
         "responses": {
           "200": {
             "description": "A successful request.",
-            "content": {}
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetAzmIntradayResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "The request had bad syntax or was inherently impossible to be satified.",
@@ -678,7 +696,13 @@
         "responses": {
           "200": {
             "description": "A successful request.",
-            "content": {}
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetAzmIntradayResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "The request had bad syntax or was inherently impossible to be satified.",
@@ -1295,7 +1319,13 @@
         "responses": {
           "200": {
             "description": "A successful request.",
-            "content": {}
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetActivityIntradayResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "The request had bad syntax or was inherently impossible to be satified.",
@@ -1369,7 +1399,13 @@
         "responses": {
           "200": {
             "description": "A successful request.",
-            "content": {}
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetActivityIntradayResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "The request had bad syntax or was inherently impossible to be satified.",
@@ -1471,7 +1507,13 @@
         "responses": {
           "200": {
             "description": "A successful request.",
-            "content": {}
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetActivityIntradayResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "The request had bad syntax or was inherently impossible to be satified.",
@@ -1563,7 +1605,13 @@
         "responses": {
           "200": {
             "description": "A successful request.",
-            "content": {}
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetActivityIntradayResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "The request had bad syntax or was inherently impossible to be satified.",
@@ -3446,8 +3494,14 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful request.",
-            "content": {}
+            "description": "A successful request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetBreathingRateIntradayResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "The request requires user authentication.",
@@ -3495,8 +3549,14 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful request.",
-            "content": {}
+            "description": "A successful request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetBreathingRateIntradayResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "The request requires user authentication.",
@@ -4290,8 +4350,14 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful request.",
-            "content": {}
+            "description": "A successful request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetHeartRateIntradayResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "The request requires user authentication.",
@@ -4377,8 +4443,14 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful request.",
-            "content": {}
+            "description": "A successful request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetHeartRateIntradayResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "The request requires user authentication.",
@@ -4436,8 +4508,14 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful request.",
-            "content": {}
+            "description": "A successful request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetHeartRateIntradayResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "The request requires user authentication.",
@@ -4513,8 +4591,14 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful request.",
-            "content": {}
+            "description": "A successful request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetHeartRateIntradayResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "The request requires user authentication.",
@@ -4662,8 +4746,14 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful request.",
-            "content": {}
+            "description": "A successful request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetHrvIntradayResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "The request requires user authentication.",
@@ -4711,8 +4801,14 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful request.",
-            "content": {}
+            "description": "A successful request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetHrvIntradayResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "The request requires user authentication.",
@@ -6858,8 +6954,14 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful request.",
-            "content": {}
+            "description": "A successful request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetSpO2IntradayResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "The request requires user authentication.",
@@ -6907,8 +7009,14 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful request.",
-            "content": {}
+            "description": "A successful request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetSpO2IntradayResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "The request requires user authentication.",
@@ -7472,6 +7580,66 @@
           },
           "value": {
             "$ref": "#/components/schemas/BreathingRateValue"
+          }
+        }
+      },
+      "HrvIntradayMinute": {
+        "type": "object",
+        "properties": {
+          "minute": {
+            "type": "string",
+            "description": "A measurement taken at a given time."
+          },
+          "value": {
+            "$ref": "#/components/schemas/HrvIntradayValue"
+          }
+        }
+      },
+      "GetHrvIntradayResponse": {
+        "type": "object",
+        "properties": {
+          "hrv": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "dateTime": {
+                  "type": "string",
+                  "format": "date"
+                },
+                "minutes": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/HrvIntradayMinute"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "HrvIntradayValue": {
+        "type": "object",
+        "properties": {
+          "rmssd": {
+            "type": "number",
+            "description": "The Root Mean Square of Successive Differences (RMSSD) between heart beats."
+          },
+          "coverage": {
+            "type": "number",
+            "description": "Data completeness in terms of the number of interbeat intervals."
+          },
+          "hf": {
+            "type": "number",
+            "description": "The power in interbeat interval fluctuations within the high frequency band (0.15 Hz - 0.4 Hz)."
+          },
+          "lf": {
+            "type": "number",
+            "description": "The power in interbeat interval fluctuations within the low frequency band (0.04 Hz - 0.15 Hz)."
+          },
+          "dailyRmssd": {
+            "type": "number",
+            "description": "The Root Mean Square of Successive Differences (RMSSD) between heart beats. (Interval response)"
           }
         }
       },
@@ -8231,6 +8399,89 @@
           }
         }
       },
+      "GetSpo2IntradayResponse": {
+        "type": "object",
+        "properties": {
+          "spo2": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "dateTime": {
+                  "type": "string",
+                  "format": "date",
+                  "description": "The sleep log date specified in the format YYYY-MM-DD."
+                },
+                "minutes": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SpO2IntradayMinute"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "Spo2IntradayMinute": {
+        "type": "object",
+        "properties": {
+          "minute": {
+            "type": "string",
+            "description": "The date and time at which the SpO2 measurement was taken."
+          },
+          "value": {
+            "type": "number",
+            "description": "The percentage value of SpO2 calculated at a specific date and time in a single day."
+          }
+        }
+      },
+      "GetBreathingRateIntradayResponse": {
+        "type": "object",
+        "properties": {
+          "br": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "dateTime": {
+                  "type": "string",
+                  "format": "date"
+                },
+                "value": {
+                  "$ref": "#/components/schemas/BreathingRateIntradayValue"
+                }
+              }
+            }
+          }
+        }
+      },
+      "BreathingRateIntradayValue": {
+        "type": "object",
+        "properties": {
+          "lightSleepSummary": {
+            "$ref": "#/components/schemas/BreathingRateIntradaySummary"
+          },
+          "deepSleepSummary": {
+            "$ref": "#/components/schemas/BreathingRateIntradaySummary"
+          },
+          "remSleepSummary": {
+            "$ref": "#/components/schemas/BreathingRateIntradaySummary"
+          },
+          "fullSleepSummary": {
+            "$ref": "#/components/schemas/BreathingRateIntradaySummary"
+          }
+        }
+      },
+      "BreathingRateIntradaySummary": {
+        "type": "object",
+        "properties": {
+          "breathingRate": {
+            "type": "number",
+            "description": "Average number of breaths taken per minute."
+          }
+        }
+      },
       "GetBodyFatLogResponse": {
         "type": "object",
         "properties": {
@@ -8658,6 +8909,81 @@
           }
         }
       },
+      "AzmIntradayDataset": {
+        "type": "object",
+        "properties": {
+          "dataset": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AzmIntradayDatapoint"
+            }
+          },
+          "datasetInterval": {
+            "type": "integer",
+            "description": "The requested detail-level numerical interval"
+          },
+          "datasetType": {
+            "type": "string",
+            "description": "The requested detail-level unit of measure"
+          }
+        }
+      },
+      "GetAzmIntradayResponse": {
+        "type": "object",
+        "properties": {
+          "activities-active-zone-minutes": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "dateTime": {
+                  "type": "string",
+                  "format": "date"
+                },
+                "value": {
+                  "$ref": "#/components/schemas/AzmValue"
+                }
+              }
+            }
+          },
+          "activities-active-zone-minutes-intraday": {
+            "$ref": "#/components/schemas/AzmIntradayDataset"
+          }
+        }
+      },
+      "AzmValue": {
+        "type": "object",
+        "properties": {
+          "activeZoneMinutes": {
+            "type": "integer",
+            "description": "Total count of active zone minutes earned."
+          },
+          "fatBurnActiveZoneMinutes": {
+            "type": "integer",
+            "description": "The number of active zone minutes in the fat burn heart rate zone."
+          },
+          "cardioActiveZoneMinutes": {
+            "type": "integer",
+            "description": "The number of active zone minutes in the cardio heart rate zone."
+          },
+          "peakActiveZoneMinutes": {
+            "type": "integer",
+            "description": "The number of active zone minutes in the peak heart rate zone."
+          }
+        }
+      },
+      "AzmIntradayDatapoint": {
+        "type": "object",
+        "properties": {
+          "time": {
+            "type": "string",
+            "description": "The time of the recorded resource."
+          },
+          "value": {
+            "$ref": "#/components/schemas/AzmValue"
+          }
+        }
+      },
       "Subscription": {
         "type": "object",
         "properties": {
@@ -9029,6 +9355,52 @@
                 }
               }
             }
+          }
+        }
+      },
+      "HeartRateIntradayDatapoint": {
+        "type": "object",
+        "properties": {
+          "time": {
+            "type": "string",
+            "description": "The time the intraday heart rate value was recorded"
+          },
+          "value": {
+            "type": "number",
+            "description": "The intraday heart rate value"
+          }
+        }
+      },
+      "GetHeartRateIntradayResponse": {
+        "type": "object",
+        "properties": {
+          "activities-heart": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HeartRateTimeSeriesDatapoint"
+            }
+          },
+          "activities-heart-intraday": {
+            "$ref": "#/components/schemas/HeartRateIntradayDataset"
+          }
+        }
+      },
+      "HeartRateIntradayDataset": {
+        "type": "object",
+        "properties": {
+          "dataset": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HeartRateIntradayDatapoint"
+            }
+          },
+          "datasetInterval": {
+            "type": "integer",
+            "description": "The requested detail-level numerical interval"
+          },
+          "datasetType": {
+            "type": "string",
+            "description": "The requested detail-level unit of measure"
           }
         }
       },
@@ -10124,6 +10496,105 @@
             "type": "string",
             "description": "The type of device.",
             "enum": ["TRACKER", "SCALE"]
+          }
+        }
+      },
+      "ActivityIntradayDatapoint": {
+        "type": "object",
+        "properties": {
+          "time": {
+            "type": "string",
+            "description": "The time of the recorded resource."
+          },
+          "value": {
+            "type": "number",
+            "description": "The specified resource's value at the time it is recorded."
+          },
+          "level": {
+            "type": "integer",
+            "description": "Numerical value representing the user's activity-level at the moment when the resource was recorded. 0 = sedentary 1 = lightly active 2 = fairly/moderately active 3 = very active Returned only when resource = calories."
+          },
+          "mets": {
+            "type": "integer",
+            "description": "METs value at the moment when the resource was recorded. Returned only when resource = calories."
+          }
+        }
+      },
+      "ActivityIntradayDataset": {
+        "type": "object",
+        "properties": {
+          "dataset": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ActivityIntradayDatapoint"
+            }
+          },
+          "datasetInterval": {
+            "type": "integer",
+            "description": "The requested detail-level numerical interval"
+          },
+          "datasetType": {
+            "type": "string",
+            "description": "The requested detail-level unit of measure"
+          }
+        }
+      },
+      "GetActivityIntradayResponse": {
+        "type": "object",
+        "properties": {
+          "activities-calories": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ActivityTimeSeriesDatapoint"
+            }
+          },
+          "activities-calories-intraday": {
+            "$ref": "#/components/schemas/ActivityIntradayDataset"
+          },
+          "activities-distance": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ActivityTimeSeriesDatapoint"
+            }
+          },
+          "activities-distance-intraday": {
+            "$ref": "#/components/schemas/ActivityIntradayDataset"
+          },
+          "activities-elevation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ActivityTimeSeriesDatapoint"
+            }
+          },
+          "activities-elevation-intraday": {
+            "$ref": "#/components/schemas/ActivityIntradayDataset"
+          },
+          "activities-floors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ActivityTimeSeriesDatapoint"
+            }
+          },
+          "activities-floors-intraday": {
+            "$ref": "#/components/schemas/ActivityIntradayDataset"
+          },
+          "activities-steps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ActivityTimeSeriesDatapoint"
+            }
+          },
+          "activities-steps-intraday": {
+            "$ref": "#/components/schemas/ActivityIntradayDataset"
+          },
+          "activities-swimming-strokes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ActivityTimeSeriesDatapoint"
+            }
+          },
+          "activities-swimming-strokes-intraday": {
+            "$ref": "#/components/schemas/ActivityIntradayDataset"
           }
         }
       }

--- a/openapi/model/active_zone_minutes_intraday/azm_intraday_datapoint.json
+++ b/openapi/model/active_zone_minutes_intraday/azm_intraday_datapoint.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "time": {
+      "type": "string",
+      "description": "The time of the recorded resource."
+    },
+    "value": {
+      "$ref": "#/components/schemas/AzmValue"
+    }
+  }
+}

--- a/openapi/model/active_zone_minutes_intraday/azm_intraday_dataset.json
+++ b/openapi/model/active_zone_minutes_intraday/azm_intraday_dataset.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "dataset": {
+      "type": "array",
+      "items": {
+        "$ref": "#/components/schemas/AzmIntradayDatapoint"
+      }
+    },
+    "datasetInterval": {
+      "type": "integer",
+      "description": "The requested detail-level numerical interval"
+    },
+    "datasetType": {
+      "type": "string",
+      "description": "The requested detail-level unit of measure"
+    }
+  }
+}

--- a/openapi/model/active_zone_minutes_intraday/azm_value.json
+++ b/openapi/model/active_zone_minutes_intraday/azm_value.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "activeZoneMinutes": {
+      "type": "integer",
+      "description": "Total count of active zone minutes earned."
+    },
+    "fatBurnActiveZoneMinutes": {
+      "type": "integer",
+      "description": "The number of active zone minutes in the fat burn heart rate zone."
+    },
+    "cardioActiveZoneMinutes": {
+      "type": "integer",
+      "description": "The number of active zone minutes in the cardio heart rate zone."
+    },
+    "peakActiveZoneMinutes": {
+      "type": "integer",
+      "description": "The number of active zone minutes in the peak heart rate zone."
+    }
+  }
+}

--- a/openapi/model/active_zone_minutes_intraday/get_azm_intraday_response.json
+++ b/openapi/model/active_zone_minutes_intraday/get_azm_intraday_response.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "activities-active-zone-minutes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "dateTime": {
+            "type": "string",
+            "format": "date"
+          },
+          "value": {
+            "$ref": "#/components/schemas/AzmValue"
+          }
+        }
+      }
+    },
+    "activities-active-zone-minutes-intraday": {
+      "$ref": "#/components/schemas/AzmIntradayDataset"
+    }
+  }
+}

--- a/openapi/model/activity_intraday/activity_intraday_datapoint.json
+++ b/openapi/model/activity_intraday/activity_intraday_datapoint.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "time": {
+      "type": "string",
+      "description": "The time of the recorded resource."
+    },
+    "value": {
+      "type": "number",
+      "description": "The specified resource's value at the time it is recorded."
+    },
+    "level": {
+      "type": "integer",
+      "description": "Numerical value representing the user's activity-level at the moment when the resource was recorded. 0 = sedentary 1 = lightly active 2 = fairly/moderately active 3 = very active Returned only when resource = calories."
+    },
+    "mets": {
+      "type": "integer",
+      "description": "METs value at the moment when the resource was recorded. Returned only when resource = calories."
+    }
+  }
+}

--- a/openapi/model/activity_intraday/activity_intraday_dataset.json
+++ b/openapi/model/activity_intraday/activity_intraday_dataset.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "dataset": {
+      "type": "array",
+      "items": {
+        "$ref": "#/components/schemas/ActivityIntradayDatapoint"
+      }
+    },
+    "datasetInterval": {
+      "type": "integer",
+      "description": "The requested detail-level numerical interval"
+    },
+    "datasetType": {
+      "type": "string",
+      "description": "The requested detail-level unit of measure"
+    }
+  }
+}

--- a/openapi/model/activity_intraday/get_activity_intraday_response.json
+++ b/openapi/model/activity_intraday/get_activity_intraday_response.json
@@ -1,0 +1,59 @@
+{
+  "type": "object",
+  "properties": {
+    "activities-calories": {
+      "type": "array",
+      "items": {
+        "$ref": "#/components/schemas/ActivityTimeSeriesDatapoint"
+      }
+    },
+    "activities-calories-intraday": {
+      "$ref": "#/components/schemas/ActivityIntradayDataset"
+    },
+    "activities-distance": {
+      "type": "array",
+      "items": {
+        "$ref": "#/components/schemas/ActivityTimeSeriesDatapoint"
+      }
+    },
+    "activities-distance-intraday": {
+      "$ref": "#/components/schemas/ActivityIntradayDataset"
+    },
+    "activities-elevation": {
+      "type": "array",
+      "items": {
+        "$ref": "#/components/schemas/ActivityTimeSeriesDatapoint"
+      }
+    },
+    "activities-elevation-intraday": {
+      "$ref": "#/components/schemas/ActivityIntradayDataset"
+    },
+    "activities-floors": {
+      "type": "array",
+      "items": {
+        "$ref": "#/components/schemas/ActivityTimeSeriesDatapoint"
+      }
+    },
+    "activities-floors-intraday": {
+      "$ref": "#/components/schemas/ActivityIntradayDataset"
+    },
+    "activities-steps": {
+      "type": "array",
+      "items": {
+        "$ref": "#/components/schemas/ActivityTimeSeriesDatapoint"
+      }
+    },
+    "activities-steps-intraday": {
+      "$ref": "#/components/schemas/ActivityIntradayDataset"
+    },
+    "activities-swimming-strokes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/components/schemas/ActivityTimeSeriesDatapoint"
+      }
+    },
+    "activities-swimming-strokes-intraday": {
+      "$ref": "#/components/schemas/ActivityIntradayDataset"
+    }
+  }
+}

--- a/openapi/model/breathing_rate_intraday/breathing_rate_intraday_summary.json
+++ b/openapi/model/breathing_rate_intraday/breathing_rate_intraday_summary.json
@@ -1,0 +1,9 @@
+{
+  "type": "object",
+  "properties": {
+    "breathingRate": {
+      "type": "number",
+      "description": "Average number of breaths taken per minute."
+    }
+  }
+}

--- a/openapi/model/breathing_rate_intraday/breathing_rate_intraday_value.json
+++ b/openapi/model/breathing_rate_intraday/breathing_rate_intraday_value.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "lightSleepSummary": {
+      "$ref": "#/components/schemas/BreathingRateIntradaySummary"
+    },
+    "deepSleepSummary": {
+      "$ref": "#/components/schemas/BreathingRateIntradaySummary"
+    },
+    "remSleepSummary": {
+      "$ref": "#/components/schemas/BreathingRateIntradaySummary"
+    },
+    "fullSleepSummary": {
+      "$ref": "#/components/schemas/BreathingRateIntradaySummary"
+    }
+  }
+}

--- a/openapi/model/breathing_rate_intraday/get_breathing_rate_intraday_response.json
+++ b/openapi/model/breathing_rate_intraday/get_breathing_rate_intraday_response.json
@@ -1,0 +1,20 @@
+{
+  "type": "object",
+  "properties": {
+    "br": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "dateTime": {
+            "type": "string",
+            "format": "date"
+          },
+          "value": {
+            "$ref": "#/components/schemas/BreathingRateIntradayValue"
+          }
+        }
+      }
+    }
+  }
+}

--- a/openapi/model/heart_rate_intraday/get_heart_rate_intraday_response.json
+++ b/openapi/model/heart_rate_intraday/get_heart_rate_intraday_response.json
@@ -1,0 +1,14 @@
+{
+  "type": "object",
+  "properties": {
+    "activities-heart": {
+      "type": "array",
+      "items": {
+        "$ref": "#/components/schemas/HeartRateTimeSeriesDatapoint"
+      }
+    },
+    "activities-heart-intraday": {
+      "$ref": "#/components/schemas/HeartRateIntradayDataset"
+    }
+  }
+}

--- a/openapi/model/heart_rate_intraday/heart_rate_intraday_datapoint.json
+++ b/openapi/model/heart_rate_intraday/heart_rate_intraday_datapoint.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "time": {
+      "type": "string",
+      "description": "The time the intraday heart rate value was recorded"
+    },
+    "value": {
+      "type": "number",
+      "description": "The intraday heart rate value"
+    }
+  }
+}

--- a/openapi/model/heart_rate_intraday/heart_rate_intraday_dataset.json
+++ b/openapi/model/heart_rate_intraday/heart_rate_intraday_dataset.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "dataset": {
+      "type": "array",
+      "items": {
+        "$ref": "#/components/schemas/HeartRateIntradayDatapoint"
+      }
+    },
+    "datasetInterval": {
+      "type": "integer",
+      "description": "The requested detail-level numerical interval"
+    },
+    "datasetType": {
+      "type": "string",
+      "description": "The requested detail-level unit of measure"
+    }
+  }
+}

--- a/openapi/model/heart_rate_variability_intraday/get_hrv_intraday_response.json
+++ b/openapi/model/heart_rate_variability_intraday/get_hrv_intraday_response.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "hrv": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "dateTime": {
+            "type": "string",
+            "format": "date"
+          },
+          "minutes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HrvIntradayMinute"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/openapi/model/heart_rate_variability_intraday/hrv_intraday_minute.json
+++ b/openapi/model/heart_rate_variability_intraday/hrv_intraday_minute.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "minute": {
+      "type": "string",
+      "description": "A measurement taken at a given time."
+    },
+    "value": {
+      "$ref": "#/components/schemas/HrvIntradayValue"
+    }
+  }
+}

--- a/openapi/model/heart_rate_variability_intraday/hrv_intraday_value.json
+++ b/openapi/model/heart_rate_variability_intraday/hrv_intraday_value.json
@@ -1,0 +1,25 @@
+{
+  "type": "object",
+  "properties": {
+    "rmssd": {
+      "type": "number",
+      "description": "The Root Mean Square of Successive Differences (RMSSD) between heart beats."
+    },
+    "coverage": {
+      "type": "number",
+      "description": "Data completeness in terms of the number of interbeat intervals."
+    },
+    "hf": {
+      "type": "number",
+      "description": "The power in interbeat interval fluctuations within the high frequency band (0.15 Hz - 0.4 Hz)."
+    },
+    "lf": {
+      "type": "number",
+      "description": "The power in interbeat interval fluctuations within the low frequency band (0.04 Hz - 0.15 Hz)."
+    },
+    "dailyRmssd": {
+      "type": "number",
+      "description": "The Root Mean Square of Successive Differences (RMSSD) between heart beats. (Interval response)"
+    }
+  }
+}

--- a/openapi/model/spo2_intraday/get_spo2_intraday_response.json
+++ b/openapi/model/spo2_intraday/get_spo2_intraday_response.json
@@ -1,0 +1,24 @@
+{
+  "type": "object",
+  "properties": {
+    "spo2": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "dateTime": {
+            "type": "string",
+            "format": "date",
+            "description": "The sleep log date specified in the format YYYY-MM-DD."
+          },
+          "minutes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpO2IntradayMinute"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/openapi/model/spo2_intraday/spo2_intraday_minute.json
+++ b/openapi/model/spo2_intraday/spo2_intraday_minute.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "minute": {
+      "type": "string",
+      "description": "The date and time at which the SpO2 measurement was taken."
+    },
+    "value": {
+      "type": "number",
+      "description": "The percentage value of SpO2 calculated at a specific date and time in a single day."
+    }
+  }
+}

--- a/openapi/paths/active_zone_minutes_intraday_paths.json
+++ b/openapi/paths/active_zone_minutes_intraday_paths.json
@@ -1,0 +1,22 @@
+{
+  "/1/user/-/activities/active-zone-minutes/date/{date}/1d/{detail-level}.json": {
+    "get": {
+      "200": "GetAzmIntradayResponse"
+    }
+  },
+  "/1/user/-/activities/active-zone-minutes/date/{date}/1d/{detail-level}/time/{start-time}/{end-time}.json": {
+    "get": {
+      "200": "GetAzmIntradayResponse"
+    }
+  },
+  "/1/user/-/activities/active-zone-minutes/date/{start-date}/{end-date}/{detail-level}.json": {
+    "get": {
+      "200": "GetAzmIntradayResponse"
+    }
+  },
+  "/1/user/-/activities/active-zone-minutes/date/{start-date}/{end-date}/time/{start-time}/{end-time}.json": {
+    "get": {
+      "200": "GetAzmIntradayResponse"
+    }
+  }
+}

--- a/openapi/paths/activity_intraday_paths.json
+++ b/openapi/paths/activity_intraday_paths.json
@@ -1,0 +1,22 @@
+{
+  "/1/user/-/activities/{resource-path}/date/{date}/1d/{detail-level}.json": {
+    "get": {
+      "200": "GetActivityIntradayResponse"
+    }
+  },
+  "/1/user/-/activities/{resource-path}/date/{date}/1d/{detail-level}/time/{start-time}/{end-time}.json": {
+    "get": {
+      "200": "GetActivityIntradayResponse"
+    }
+  },
+  "/1/user/-/activities/{resource-path}/date/{base-date}/{end-date}/{detail-level}.json": {
+    "get": {
+      "200": "GetActivityIntradayResponse"
+    }
+  },
+  "/1/user/-/activities/{resource-path}/date/{date}/{end-date}/{detail-level}/time/{start-time}/{end-time}.json": {
+    "get": {
+      "200": "GetActivityIntradayResponse"
+    }
+  }
+}

--- a/openapi/paths/breathing_rate_intraday_paths.json
+++ b/openapi/paths/breathing_rate_intraday_paths.json
@@ -1,0 +1,12 @@
+{
+  "/1/user/-/br/date/{date}/all.json": {
+    "get": {
+      "200": "GetBreathingRateIntradayResponse"
+    }
+  },
+  "/1/user/-/br/date/{startDate}/{endDate}/all.json": {
+    "get": {
+      "200": "GetBreathingRateIntradayResponse"
+    }
+  }
+}

--- a/openapi/paths/heart_rate_intraday_paths.json
+++ b/openapi/paths/heart_rate_intraday_paths.json
@@ -1,0 +1,22 @@
+{
+  "/1/user/-/activities/heart/date/{date}/1d/{detail-level}.json": {
+    "get": {
+      "200": "GetHeartRateIntradayResponse"
+    }
+  },
+  "/1/user/-/activities/heart/date/{date}/1d/{detail-level}/time/{start-time}/{end-time}.json": {
+    "get": {
+      "200": "GetHeartRateIntradayResponse"
+    }
+  },
+  "/1/user/-/activities/heart/date/{date}/{end-date}/{detail-level}.json": {
+    "get": {
+      "200": "GetHeartRateIntradayResponse"
+    }
+  },
+  "/1/user/-/activities/heart/date/{date}/{end-date}/{detail-level}/time/{start-time}/{end-time}.json": {
+    "get": {
+      "200": "GetHeartRateIntradayResponse"
+    }
+  }
+}

--- a/openapi/paths/heart_rate_variability_intraday_paths.json
+++ b/openapi/paths/heart_rate_variability_intraday_paths.json
@@ -1,0 +1,12 @@
+{
+  "/1/user/-/hrv/date/{date}/all.json": {
+    "get": {
+      "200": "GetHrvIntradayResponse"
+    }
+  },
+  "/1/user/-/hrv/date/{startDate}/{endDate}/all.json": {
+    "get": {
+      "200": "GetHrvIntradayResponse"
+    }
+  }
+}

--- a/openapi/paths/spo2_intraday_paths.json
+++ b/openapi/paths/spo2_intraday_paths.json
@@ -1,0 +1,12 @@
+{
+  "/1/user/-/spo2/date/{date}/all.json": {
+    "get": {
+      "200": "GetSpO2IntradayResponse"
+    }
+  },
+  "/1/user/-/spo2/date/{startDate}/{endDate}/all.json": {
+    "get": {
+      "200": "GetSpO2IntradayResponse"
+    }
+  }
+}


### PR DESCRIPTION
This and models and paths for active zone minutes, activity, breathing rate, heart rate, heart rate variability, and SpO2

- Implemented schemas for GetAzmIntradayResponse, AzmIntradayDataset, AzmValue, and AzmIntradayDatapoint.
- Created models for activity intraday data including GetActivityIntradayResponse, ActivityIntradayDataset, and ActivityIntradayDatapoint.
- Added breathing rate intraday response models: GetBreathingRateIntradayResponse, BreathingRateIntradayValue, and BreathingRateIntradaySummary.
- Developed heart rate intraday response models: GetHeartRateIntradayResponse, HeartRateIntradayDataset, and HeartRateIntradayDatapoint.
- Introduced heart rate variability models: GetHrvIntradayResponse, HrvIntradayMinute, and HrvIntradayValue.
- Added SpO2 intraday response models: GetSpo2IntradayResponse, SpO2IntradayMinute.
- Created paths for all new endpoints to retrieve intraday data for active zone minutes, activity, breathing rate, heart rate, heart rate variability, and SpO2.