### PR TITLE
fix: convert all parameters with X.XX format description to float/number types

### DIFF
--- a/docs/ActivityApi.md
+++ b/docs/ActivityApi.md
@@ -59,7 +59,7 @@ async with fitbit_web_api.ApiClient(configuration) as api_client:
     start_time = 'start_time_example' # str | Activity start time. Hours and minutes in the format HH:mm:ss.
     duration_millis = 56 # int | Duration in milliseconds.
     var_date = '2013-10-20' # date | Log entry date in the format yyyy-MM-dd.
-    distance = 56 # int | Distance is required for logging directory activity in the format X.XX and in the selected distanceUnit.
+    distance = 3.4 # float | Distance is required for logging directory activity in the format X.XX and in the selected distanceUnit.
     activity_name = 'activity_name_example' # str | Custom activity name. Either activityId or activityName must be provided. (optional)
     distance_unit = 56 # int | Distance measurement unit. Steps units are available only for Walking (activityId=90013) and Running (activityId=90009) directory activities and their intensity levels. (optional)
 
@@ -72,16 +72,16 @@ async with fitbit_web_api.ApiClient(configuration) as api_client:
 
 ### Parameters
 
-| Name                | Type     | Description                                                                                                                                                                        | Notes      |
-| ------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
-| **activity_id**     | **int**  | The ID of the activity, directory activity or intensity level activity.                                                                                                            |
-| **manual_calories** | **int**  | Calories burned that are manaully specified. Required with activityName must be provided.                                                                                          |
-| **start_time**      | **str**  | Activity start time. Hours and minutes in the format HH:mm:ss.                                                                                                                     |
-| **duration_millis** | **int**  | Duration in milliseconds.                                                                                                                                                          |
-| **var_date**        | **date** | Log entry date in the format yyyy-MM-dd.                                                                                                                                           |
-| **distance**        | **int**  | Distance is required for logging directory activity in the format X.XX and in the selected distanceUnit.                                                                           |
-| **activity_name**   | **str**  | Custom activity name. Either activityId or activityName must be provided.                                                                                                          | [optional] |
-| **distance_unit**   | **int**  | Distance measurement unit. Steps units are available only for Walking (activityId&#x3D;90013) and Running (activityId&#x3D;90009) directory activities and their intensity levels. | [optional] |
+| Name                | Type      | Description                                                                                                                                                                        | Notes      |
+| ------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| **activity_id**     | **int**   | The ID of the activity, directory activity or intensity level activity.                                                                                                            |
+| **manual_calories** | **int**   | Calories burned that are manaully specified. Required with activityName must be provided.                                                                                          |
+| **start_time**      | **str**   | Activity start time. Hours and minutes in the format HH:mm:ss.                                                                                                                     |
+| **duration_millis** | **int**   | Duration in milliseconds.                                                                                                                                                          |
+| **var_date**        | **date**  | Log entry date in the format yyyy-MM-dd.                                                                                                                                           |
+| **distance**        | **float** | Distance is required for logging directory activity in the format X.XX and in the selected distanceUnit.                                                                           |
+| **activity_name**   | **str**   | Custom activity name. Either activityId or activityName must be provided.                                                                                                          | [optional] |
+| **distance_unit**   | **int**   | Distance measurement unit. Steps units are available only for Walking (activityId&#x3D;90013) and Running (activityId&#x3D;90009) directory activities and their intensity levels. | [optional] |
 
 ### Return type
 

--- a/docs/BodyApi.md
+++ b/docs/BodyApi.md
@@ -883,7 +883,7 @@ configuration.access_token = os.environ["ACCESS_TOKEN"]
 async with fitbit_web_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fitbit_web_api.BodyApi(api_client)
-    fat = 'fat_example' # str | Target body fat percentage; in the format X.XX.
+    fat = 3.4 # float | Target body fat percentage; in the format X.XX.
 
     try:
         # Update Body Fat Goal
@@ -894,9 +894,9 @@ async with fitbit_web_api.ApiClient(configuration) as api_client:
 
 ### Parameters
 
-| Name    | Type    | Description                                     | Notes |
-| ------- | ------- | ----------------------------------------------- | ----- |
-| **fat** | **str** | Target body fat percentage; in the format X.XX. |
+| Name    | Type      | Description                                     | Notes |
+| ------- | --------- | ----------------------------------------------- | ----- |
+| **fat** | **float** | Target body fat percentage; in the format X.XX. |
 
 ### Return type
 
@@ -957,8 +957,8 @@ async with fitbit_web_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fitbit_web_api.BodyApi(api_client)
     start_date = 'start_date_example' # str | Weight goal start date; in the format yyyy-MM-dd.
-    start_weight = 'start_weight_example' # str | Weight goal start weight; in the format X.XX, in the unit systems that corresponds to the Accept-Language header provided.
-    weight = 'weight_example' # str | Weight goal target weight; in the format X.XX, in the unit systems that corresponds to the Accept-Language header provided; required if user doesn't have an existing weight goal. (optional)
+    start_weight = 3.4 # float | Weight goal start weight; in the format X.XX, in the unit systems that corresponds to the Accept-Language header provided.
+    weight = 3.4 # float | Weight goal target weight; in the format X.XX, in the unit systems that corresponds to the Accept-Language header provided; required if user doesn't have an existing weight goal. (optional)
 
     try:
         # Update Weight Goal
@@ -969,11 +969,11 @@ async with fitbit_web_api.ApiClient(configuration) as api_client:
 
 ### Parameters
 
-| Name             | Type    | Description                                                                                                                                                                            | Notes      |
-| ---------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
-| **start_date**   | **str** | Weight goal start date; in the format yyyy-MM-dd.                                                                                                                                      |
-| **start_weight** | **str** | Weight goal start weight; in the format X.XX, in the unit systems that corresponds to the Accept-Language header provided.                                                             |
-| **weight**       | **str** | Weight goal target weight; in the format X.XX, in the unit systems that corresponds to the Accept-Language header provided; required if user doesn&#39;t have an existing weight goal. | [optional] |
+| Name             | Type      | Description                                                                                                                                                                            | Notes      |
+| ---------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| **start_date**   | **str**   | Weight goal start date; in the format yyyy-MM-dd.                                                                                                                                      |
+| **start_weight** | **float** | Weight goal start weight; in the format X.XX, in the unit systems that corresponds to the Accept-Language header provided.                                                             |
+| **weight**       | **float** | Weight goal target weight; in the format X.XX, in the unit systems that corresponds to the Accept-Language header provided; required if user doesn&#39;t have an existing weight goal. | [optional] |
 
 ### Return type
 

--- a/docs/NutritionApi.md
+++ b/docs/NutritionApi.md
@@ -226,7 +226,7 @@ async with fitbit_web_api.ApiClient(configuration) as api_client:
     food_id = 'food_id_example' # str | The ID of the food to be logged. Either foodId or foodName must be provided.
     meal_type_id = 'meal_type_id_example' # str | Meal types. 1=Breakfast; 2=Morning Snack; 3=Lunch; 4=Afternoon Snack; 5=Dinner; 7=Anytime.
     unit_id = 'unit_id_example' # str | The ID of units used. Typically retrieved via a previous call to Get Food Logs, Search Foods, or Get Food Units.
-    amount = 'amount_example' # str | The amount consumed in the format X.XX in the specified unitId.
+    amount = 3.4 # float | The amount consumed in the format X.XX in the specified unitId.
     var_date = '2013-10-20' # date | Log entry date in the format yyyy-MM-dd.
     food_name = 'food_name_example' # str | Food entry name. Either foodId or foodName must be provided. (optional)
     favorite = True # bool | The `true` value will add the food to the user's favorites after creating the log entry; while the `false` value will not. Valid only with foodId value. (optional)
@@ -242,17 +242,17 @@ async with fitbit_web_api.ApiClient(configuration) as api_client:
 
 ### Parameters
 
-| Name             | Type     | Description                                                                                                                                                                      | Notes      |
-| ---------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
-| **food_id**      | **str**  | The ID of the food to be logged. Either foodId or foodName must be provided.                                                                                                     |
-| **meal_type_id** | **str**  | Meal types. 1&#x3D;Breakfast; 2&#x3D;Morning Snack; 3&#x3D;Lunch; 4&#x3D;Afternoon Snack; 5&#x3D;Dinner; 7&#x3D;Anytime.                                                         |
-| **unit_id**      | **str**  | The ID of units used. Typically retrieved via a previous call to Get Food Logs, Search Foods, or Get Food Units.                                                                 |
-| **amount**       | **str**  | The amount consumed in the format X.XX in the specified unitId.                                                                                                                  |
-| **var_date**     | **date** | Log entry date in the format yyyy-MM-dd.                                                                                                                                         |
-| **food_name**    | **str**  | Food entry name. Either foodId or foodName must be provided.                                                                                                                     | [optional] |
-| **favorite**     | **bool** | The &#x60;true&#x60; value will add the food to the user&#39;s favorites after creating the log entry; while the &#x60;false&#x60; value will not. Valid only with foodId value. | [optional] |
-| **brand_name**   | **str**  | Brand name of food. Valid only with foodName parameters.                                                                                                                         | [optional] |
-| **calories**     | **int**  | Calories for this serving size. This is allowed with foodName parameter (default to zero); otherwise it is ignored.                                                              | [optional] |
+| Name             | Type      | Description                                                                                                                                                                      | Notes      |
+| ---------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| **food_id**      | **str**   | The ID of the food to be logged. Either foodId or foodName must be provided.                                                                                                     |
+| **meal_type_id** | **str**   | Meal types. 1&#x3D;Breakfast; 2&#x3D;Morning Snack; 3&#x3D;Lunch; 4&#x3D;Afternoon Snack; 5&#x3D;Dinner; 7&#x3D;Anytime.                                                         |
+| **unit_id**      | **str**   | The ID of units used. Typically retrieved via a previous call to Get Food Logs, Search Foods, or Get Food Units.                                                                 |
+| **amount**       | **float** | The amount consumed in the format X.XX in the specified unitId.                                                                                                                  |
+| **var_date**     | **date**  | Log entry date in the format yyyy-MM-dd.                                                                                                                                         |
+| **food_name**    | **str**   | Food entry name. Either foodId or foodName must be provided.                                                                                                                     | [optional] |
+| **favorite**     | **bool**  | The &#x60;true&#x60; value will add the food to the user&#39;s favorites after creating the log entry; while the &#x60;false&#x60; value will not. Valid only with foodId value. | [optional] |
+| **brand_name**   | **str**   | Brand name of food. Valid only with foodName parameters.                                                                                                                         | [optional] |
+| **calories**     | **int**   | Calories for this serving size. This is allowed with foodName parameter (default to zero); otherwise it is ignored.                                                              | [optional] |
 
 ### Return type
 
@@ -537,7 +537,7 @@ async with fitbit_web_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = fitbit_web_api.NutritionApi(api_client)
     var_date = '2013-10-20' # date | The date of records to be returned in the format yyyy-MM-dd.
-    amount = 56 # int | The amount consumption in the format X.XX and in the specified waterUnit or in the unit system that corresponds to the Accept-Language header provided.
+    amount = 3.4 # float | The amount consumption in the format X.XX and in the specified waterUnit or in the unit system that corresponds to the Accept-Language header provided.
     unit = 'unit_example' # str | Water measurement unit; `ml`, `fl oz`, or `cup`. (optional)
 
     try:
@@ -549,11 +549,11 @@ async with fitbit_web_api.ApiClient(configuration) as api_client:
 
 ### Parameters
 
-| Name         | Type     | Description                                                                                                                                             | Notes      |
-| ------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
-| **var_date** | **date** | The date of records to be returned in the format yyyy-MM-dd.                                                                                            |
-| **amount**   | **int**  | The amount consumption in the format X.XX and in the specified waterUnit or in the unit system that corresponds to the Accept-Language header provided. |
-| **unit**     | **str**  | Water measurement unit; &#x60;ml&#x60;, &#x60;fl oz&#x60;, or &#x60;cup&#x60;.                                                                          | [optional] |
+| Name         | Type      | Description                                                                                                                                             | Notes      |
+| ------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| **var_date** | **date**  | The date of records to be returned in the format yyyy-MM-dd.                                                                                            |
+| **amount**   | **float** | The amount consumption in the format X.XX and in the specified waterUnit or in the unit system that corresponds to the Accept-Language header provided. |
+| **unit**     | **str**   | Water measurement unit; &#x60;ml&#x60;, &#x60;fl oz&#x60;, or &#x60;cup&#x60;.                                                                          | [optional] |
 
 ### Return type
 
@@ -976,7 +976,7 @@ async with fitbit_web_api.ApiClient(configuration) as api_client:
     food_log_id = 'food_log_id_example' # str | The ID of the food log entry to be edited.
     meal_type_id = 'meal_type_id_example' # str | Meal types. 1=Breakfast; 2=Morning Snack; 3=Lunch; 4=Afternoon Snack; 5=Dinner; 7=Anytime.
     unit_id = 'unit_id_example' # str | The ID of units used. Typically retrieved via a previous call to Get Food Logs, Search Foods, or Get Food Units.
-    amount = 'amount_example' # str | The amount consumed in the format X.XX in the specified unitId.
+    amount = 3.4 # float | The amount consumed in the format X.XX in the specified unitId.
     calories = 56 # int | Calories for this serving size. This is allowed with foodName parameter (default to zero); otherwise it is ignored. (optional)
 
     try:
@@ -988,13 +988,13 @@ async with fitbit_web_api.ApiClient(configuration) as api_client:
 
 ### Parameters
 
-| Name             | Type    | Description                                                                                                              | Notes      |
-| ---------------- | ------- | ------------------------------------------------------------------------------------------------------------------------ | ---------- |
-| **food_log_id**  | **str** | The ID of the food log entry to be edited.                                                                               |
-| **meal_type_id** | **str** | Meal types. 1&#x3D;Breakfast; 2&#x3D;Morning Snack; 3&#x3D;Lunch; 4&#x3D;Afternoon Snack; 5&#x3D;Dinner; 7&#x3D;Anytime. |
-| **unit_id**      | **str** | The ID of units used. Typically retrieved via a previous call to Get Food Logs, Search Foods, or Get Food Units.         |
-| **amount**       | **str** | The amount consumed in the format X.XX in the specified unitId.                                                          |
-| **calories**     | **int** | Calories for this serving size. This is allowed with foodName parameter (default to zero); otherwise it is ignored.      | [optional] |
+| Name             | Type      | Description                                                                                                              | Notes      |
+| ---------------- | --------- | ------------------------------------------------------------------------------------------------------------------------ | ---------- |
+| **food_log_id**  | **str**   | The ID of the food log entry to be edited.                                                                               |
+| **meal_type_id** | **str**   | Meal types. 1&#x3D;Breakfast; 2&#x3D;Morning Snack; 3&#x3D;Lunch; 4&#x3D;Afternoon Snack; 5&#x3D;Dinner; 7&#x3D;Anytime. |
+| **unit_id**      | **str**   | The ID of units used. Typically retrieved via a previous call to Get Food Logs, Search Foods, or Get Food Units.         |
+| **amount**       | **float** | The amount consumed in the format X.XX in the specified unitId.                                                          |
+| **calories**     | **int**   | Calories for this serving size. This is allowed with foodName parameter (default to zero); otherwise it is ignored.      | [optional] |
 
 ### Return type
 

--- a/fitbit_web_api/api/activity_api.py
+++ b/fitbit_web_api/api/activity_api.py
@@ -69,7 +69,7 @@ class ActivityApi:
             date, Field(description="Log entry date in the format yyyy-MM-dd.")
         ],
         distance: Annotated[
-            StrictInt,
+            Union[StrictFloat, StrictInt],
             Field(
                 description="Distance is required for logging directory activity in the format X.XX and in the selected distanceUnit."
             ),
@@ -114,7 +114,7 @@ class ActivityApi:
         :param var_date: Log entry date in the format yyyy-MM-dd. (required)
         :type var_date: date
         :param distance: Distance is required for logging directory activity in the format X.XX and in the selected distanceUnit. (required)
-        :type distance: int
+        :type distance: float
         :param activity_name: Custom activity name. Either activityId or activityName must be provided.
         :type activity_name: str
         :param distance_unit: Distance measurement unit. Steps units are available only for Walking (activityId=90013) and Running (activityId=90009) directory activities and their intensity levels.
@@ -198,7 +198,7 @@ class ActivityApi:
             date, Field(description="Log entry date in the format yyyy-MM-dd.")
         ],
         distance: Annotated[
-            StrictInt,
+            Union[StrictFloat, StrictInt],
             Field(
                 description="Distance is required for logging directory activity in the format X.XX and in the selected distanceUnit."
             ),
@@ -243,7 +243,7 @@ class ActivityApi:
         :param var_date: Log entry date in the format yyyy-MM-dd. (required)
         :type var_date: date
         :param distance: Distance is required for logging directory activity in the format X.XX and in the selected distanceUnit. (required)
-        :type distance: int
+        :type distance: float
         :param activity_name: Custom activity name. Either activityId or activityName must be provided.
         :type activity_name: str
         :param distance_unit: Distance measurement unit. Steps units are available only for Walking (activityId=90013) and Running (activityId=90009) directory activities and their intensity levels.
@@ -327,7 +327,7 @@ class ActivityApi:
             date, Field(description="Log entry date in the format yyyy-MM-dd.")
         ],
         distance: Annotated[
-            StrictInt,
+            Union[StrictFloat, StrictInt],
             Field(
                 description="Distance is required for logging directory activity in the format X.XX and in the selected distanceUnit."
             ),
@@ -372,7 +372,7 @@ class ActivityApi:
         :param var_date: Log entry date in the format yyyy-MM-dd. (required)
         :type var_date: date
         :param distance: Distance is required for logging directory activity in the format X.XX and in the selected distanceUnit. (required)
-        :type distance: int
+        :type distance: float
         :param activity_name: Custom activity name. Either activityId or activityName must be provided.
         :type activity_name: str
         :param distance_unit: Distance measurement unit. Steps units are available only for Walking (activityId=90013) and Running (activityId=90009) directory activities and their intensity levels.

--- a/fitbit_web_api/api/body_api.py
+++ b/fitbit_web_api/api/body_api.py
@@ -3054,7 +3054,7 @@ class BodyApi:
     async def update_body_fat_goal(
         self,
         fat: Annotated[
-            StrictStr,
+            Union[StrictFloat, StrictInt],
             Field(description="Target body fat percentage; in the format X.XX."),
         ],
         _request_timeout: Union[
@@ -3075,7 +3075,7 @@ class BodyApi:
         Updates user's fat percentage goal.
 
         :param fat: Target body fat percentage; in the format X.XX. (required)
-        :type fat: str
+        :type fat: float
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -3124,7 +3124,7 @@ class BodyApi:
     async def update_body_fat_goal_with_http_info(
         self,
         fat: Annotated[
-            StrictStr,
+            Union[StrictFloat, StrictInt],
             Field(description="Target body fat percentage; in the format X.XX."),
         ],
         _request_timeout: Union[
@@ -3145,7 +3145,7 @@ class BodyApi:
         Updates user's fat percentage goal.
 
         :param fat: Target body fat percentage; in the format X.XX. (required)
-        :type fat: str
+        :type fat: float
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -3194,7 +3194,7 @@ class BodyApi:
     async def update_body_fat_goal_without_preload_content(
         self,
         fat: Annotated[
-            StrictStr,
+            Union[StrictFloat, StrictInt],
             Field(description="Target body fat percentage; in the format X.XX."),
         ],
         _request_timeout: Union[
@@ -3215,7 +3215,7 @@ class BodyApi:
         Updates user's fat percentage goal.
 
         :param fat: Target body fat percentage; in the format X.XX. (required)
-        :type fat: str
+        :type fat: float
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -3313,13 +3313,13 @@ class BodyApi:
             Field(description="Weight goal start date; in the format yyyy-MM-dd."),
         ],
         start_weight: Annotated[
-            StrictStr,
+            Union[StrictFloat, StrictInt],
             Field(
                 description="Weight goal start weight; in the format X.XX, in the unit systems that corresponds to the Accept-Language header provided."
             ),
         ],
         weight: Annotated[
-            Optional[StrictStr],
+            Optional[Union[StrictFloat, StrictInt]],
             Field(
                 description="Weight goal target weight; in the format X.XX, in the unit systems that corresponds to the Accept-Language header provided; required if user doesn't have an existing weight goal."
             ),
@@ -3344,9 +3344,9 @@ class BodyApi:
         :param start_date: Weight goal start date; in the format yyyy-MM-dd. (required)
         :type start_date: str
         :param start_weight: Weight goal start weight; in the format X.XX, in the unit systems that corresponds to the Accept-Language header provided. (required)
-        :type start_weight: str
+        :type start_weight: float
         :param weight: Weight goal target weight; in the format X.XX, in the unit systems that corresponds to the Accept-Language header provided; required if user doesn't have an existing weight goal.
-        :type weight: str
+        :type weight: float
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -3401,13 +3401,13 @@ class BodyApi:
             Field(description="Weight goal start date; in the format yyyy-MM-dd."),
         ],
         start_weight: Annotated[
-            StrictStr,
+            Union[StrictFloat, StrictInt],
             Field(
                 description="Weight goal start weight; in the format X.XX, in the unit systems that corresponds to the Accept-Language header provided."
             ),
         ],
         weight: Annotated[
-            Optional[StrictStr],
+            Optional[Union[StrictFloat, StrictInt]],
             Field(
                 description="Weight goal target weight; in the format X.XX, in the unit systems that corresponds to the Accept-Language header provided; required if user doesn't have an existing weight goal."
             ),
@@ -3432,9 +3432,9 @@ class BodyApi:
         :param start_date: Weight goal start date; in the format yyyy-MM-dd. (required)
         :type start_date: str
         :param start_weight: Weight goal start weight; in the format X.XX, in the unit systems that corresponds to the Accept-Language header provided. (required)
-        :type start_weight: str
+        :type start_weight: float
         :param weight: Weight goal target weight; in the format X.XX, in the unit systems that corresponds to the Accept-Language header provided; required if user doesn't have an existing weight goal.
-        :type weight: str
+        :type weight: float
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -3489,13 +3489,13 @@ class BodyApi:
             Field(description="Weight goal start date; in the format yyyy-MM-dd."),
         ],
         start_weight: Annotated[
-            StrictStr,
+            Union[StrictFloat, StrictInt],
             Field(
                 description="Weight goal start weight; in the format X.XX, in the unit systems that corresponds to the Accept-Language header provided."
             ),
         ],
         weight: Annotated[
-            Optional[StrictStr],
+            Optional[Union[StrictFloat, StrictInt]],
             Field(
                 description="Weight goal target weight; in the format X.XX, in the unit systems that corresponds to the Accept-Language header provided; required if user doesn't have an existing weight goal."
             ),
@@ -3520,9 +3520,9 @@ class BodyApi:
         :param start_date: Weight goal start date; in the format yyyy-MM-dd. (required)
         :type start_date: str
         :param start_weight: Weight goal start weight; in the format X.XX, in the unit systems that corresponds to the Accept-Language header provided. (required)
-        :type start_weight: str
+        :type start_weight: float
         :param weight: Weight goal target weight; in the format X.XX, in the unit systems that corresponds to the Accept-Language header provided; required if user doesn't have an existing weight goal.
-        :type weight: str
+        :type weight: float
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of

--- a/fitbit_web_api/api/nutrition_api.py
+++ b/fitbit_web_api/api/nutrition_api.py
@@ -699,7 +699,7 @@ class NutritionApi:
             ),
         ],
         amount: Annotated[
-            StrictStr,
+            Union[StrictFloat, StrictInt],
             Field(
                 description="The amount consumed in the format X.XX in the specified unitId."
             ),
@@ -755,7 +755,7 @@ class NutritionApi:
         :param unit_id: The ID of units used. Typically retrieved via a previous call to Get Food Logs, Search Foods, or Get Food Units. (required)
         :type unit_id: str
         :param amount: The amount consumed in the format X.XX in the specified unitId. (required)
-        :type amount: str
+        :type amount: float
         :param var_date: Log entry date in the format yyyy-MM-dd. (required)
         :type var_date: date
         :param food_name: Food entry name. Either foodId or foodName must be provided.
@@ -840,7 +840,7 @@ class NutritionApi:
             ),
         ],
         amount: Annotated[
-            StrictStr,
+            Union[StrictFloat, StrictInt],
             Field(
                 description="The amount consumed in the format X.XX in the specified unitId."
             ),
@@ -896,7 +896,7 @@ class NutritionApi:
         :param unit_id: The ID of units used. Typically retrieved via a previous call to Get Food Logs, Search Foods, or Get Food Units. (required)
         :type unit_id: str
         :param amount: The amount consumed in the format X.XX in the specified unitId. (required)
-        :type amount: str
+        :type amount: float
         :param var_date: Log entry date in the format yyyy-MM-dd. (required)
         :type var_date: date
         :param food_name: Food entry name. Either foodId or foodName must be provided.
@@ -981,7 +981,7 @@ class NutritionApi:
             ),
         ],
         amount: Annotated[
-            StrictStr,
+            Union[StrictFloat, StrictInt],
             Field(
                 description="The amount consumed in the format X.XX in the specified unitId."
             ),
@@ -1037,7 +1037,7 @@ class NutritionApi:
         :param unit_id: The ID of units used. Typically retrieved via a previous call to Get Food Logs, Search Foods, or Get Food Units. (required)
         :type unit_id: str
         :param amount: The amount consumed in the format X.XX in the specified unitId. (required)
-        :type amount: str
+        :type amount: float
         :param var_date: Log entry date in the format yyyy-MM-dd. (required)
         :type var_date: date
         :param food_name: Food entry name. Either foodId or foodName must be provided.
@@ -2025,7 +2025,7 @@ class NutritionApi:
             ),
         ],
         amount: Annotated[
-            StrictInt,
+            Union[StrictFloat, StrictInt],
             Field(
                 description="The amount consumption in the format X.XX and in the specified waterUnit or in the unit system that corresponds to the Accept-Language header provided."
             ),
@@ -2054,7 +2054,7 @@ class NutritionApi:
         :param var_date: The date of records to be returned in the format yyyy-MM-dd. (required)
         :type var_date: date
         :param amount: The amount consumption in the format X.XX and in the specified waterUnit or in the unit system that corresponds to the Accept-Language header provided. (required)
-        :type amount: int
+        :type amount: float
         :param unit: Water measurement unit; `ml`, `fl oz`, or `cup`.
         :type unit: str
         :param _request_timeout: timeout setting for this request. If one
@@ -2113,7 +2113,7 @@ class NutritionApi:
             ),
         ],
         amount: Annotated[
-            StrictInt,
+            Union[StrictFloat, StrictInt],
             Field(
                 description="The amount consumption in the format X.XX and in the specified waterUnit or in the unit system that corresponds to the Accept-Language header provided."
             ),
@@ -2142,7 +2142,7 @@ class NutritionApi:
         :param var_date: The date of records to be returned in the format yyyy-MM-dd. (required)
         :type var_date: date
         :param amount: The amount consumption in the format X.XX and in the specified waterUnit or in the unit system that corresponds to the Accept-Language header provided. (required)
-        :type amount: int
+        :type amount: float
         :param unit: Water measurement unit; `ml`, `fl oz`, or `cup`.
         :type unit: str
         :param _request_timeout: timeout setting for this request. If one
@@ -2201,7 +2201,7 @@ class NutritionApi:
             ),
         ],
         amount: Annotated[
-            StrictInt,
+            Union[StrictFloat, StrictInt],
             Field(
                 description="The amount consumption in the format X.XX and in the specified waterUnit or in the unit system that corresponds to the Accept-Language header provided."
             ),
@@ -2230,7 +2230,7 @@ class NutritionApi:
         :param var_date: The date of records to be returned in the format yyyy-MM-dd. (required)
         :type var_date: date
         :param amount: The amount consumption in the format X.XX and in the specified waterUnit or in the unit system that corresponds to the Accept-Language header provided. (required)
-        :type amount: int
+        :type amount: float
         :param unit: Water measurement unit; `ml`, `fl oz`, or `cup`.
         :type unit: str
         :param _request_timeout: timeout setting for this request. If one
@@ -3605,7 +3605,7 @@ class NutritionApi:
             ),
         ],
         amount: Annotated[
-            StrictStr,
+            Union[StrictFloat, StrictInt],
             Field(
                 description="The amount consumed in the format X.XX in the specified unitId."
             ),
@@ -3640,7 +3640,7 @@ class NutritionApi:
         :param unit_id: The ID of units used. Typically retrieved via a previous call to Get Food Logs, Search Foods, or Get Food Units. (required)
         :type unit_id: str
         :param amount: The amount consumed in the format X.XX in the specified unitId. (required)
-        :type amount: str
+        :type amount: float
         :param calories: Calories for this serving size. This is allowed with foodName parameter (default to zero); otherwise it is ignored.
         :type calories: int
         :param _request_timeout: timeout setting for this request. If one
@@ -3710,7 +3710,7 @@ class NutritionApi:
             ),
         ],
         amount: Annotated[
-            StrictStr,
+            Union[StrictFloat, StrictInt],
             Field(
                 description="The amount consumed in the format X.XX in the specified unitId."
             ),
@@ -3745,7 +3745,7 @@ class NutritionApi:
         :param unit_id: The ID of units used. Typically retrieved via a previous call to Get Food Logs, Search Foods, or Get Food Units. (required)
         :type unit_id: str
         :param amount: The amount consumed in the format X.XX in the specified unitId. (required)
-        :type amount: str
+        :type amount: float
         :param calories: Calories for this serving size. This is allowed with foodName parameter (default to zero); otherwise it is ignored.
         :type calories: int
         :param _request_timeout: timeout setting for this request. If one
@@ -3815,7 +3815,7 @@ class NutritionApi:
             ),
         ],
         amount: Annotated[
-            StrictStr,
+            Union[StrictFloat, StrictInt],
             Field(
                 description="The amount consumed in the format X.XX in the specified unitId."
             ),
@@ -3850,7 +3850,7 @@ class NutritionApi:
         :param unit_id: The ID of units used. Typically retrieved via a previous call to Get Food Logs, Search Foods, or Get Food Units. (required)
         :type unit_id: str
         :param amount: The amount consumed in the format X.XX in the specified unitId. (required)
-        :type amount: str
+        :type amount: float
         :param calories: Calories for this serving size. This is allowed with foodName parameter (default to zero); otherwise it is ignored.
         :type calories: int
         :param _request_timeout: timeout setting for this request. If one

--- a/openapi/fitbit-web-api-openapi-fixed.json
+++ b/openapi/fitbit-web-api-openapi-fixed.json
@@ -1736,7 +1736,7 @@
             "description": "Distance is required for logging directory activity in the format X.XX and in the selected distanceUnit.",
             "required": true,
             "schema": {
-              "type": "integer"
+              "type": "number"
             }
           },
           {
@@ -2803,7 +2803,7 @@
             "description": "Target body fat percentage; in the format X.XX.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "number"
             }
           }
         ],
@@ -2864,7 +2864,7 @@
             "description": "Weight goal start weight; in the format X.XX, in the unit systems that corresponds to the Accept-Language header provided.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "number"
             }
           },
           {
@@ -2872,7 +2872,7 @@
             "in": "query",
             "description": "Weight goal target weight; in the format X.XX, in the unit systems that corresponds to the Accept-Language header provided; required if user doesn't have an existing weight goal.",
             "schema": {
-              "type": "string"
+              "type": "number"
             }
           }
         ],
@@ -5369,7 +5369,7 @@
             "description": "The amount consumed in the format X.XX in the specified unitId.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "number"
             }
           },
           {
@@ -5472,7 +5472,7 @@
             "description": "The amount consumed in the format X.XX in the specified unitId.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "number"
             }
           },
           {
@@ -5568,7 +5568,7 @@
             "description": "The amount consumption in the format X.XX and in the specified waterUnit or in the unit system that corresponds to the Accept-Language header provided.",
             "required": true,
             "schema": {
-              "type": "integer"
+              "type": "number"
             }
           },
           {

--- a/script/upgrade-schema.py
+++ b/script/upgrade-schema.py
@@ -94,10 +94,9 @@ def fix_schema_bugs(schema: dict[str, Any]) -> None:
                 continue
             for param_obj in parameters:
                 param_name = param_obj.get("name")
-                if param_name in ("fat", "weight"):
+                if "X.XX" in param_obj.get("description", ""):
                     param_schema = param_obj.setdefault("schema", {})
-                    if param_schema.get("type") == "integer":
-                        param_schema["type"] = "number"
+                    param_schema["type"] = "number"
 
                 if param_name == "time" and "if not provided" in param_obj.get(
                     "description", ""


### PR DESCRIPTION
Converts all API parameters (such as amount, distance, weight, and fat) that specify an 'X.XX' format in their description to use the 'number' (float) type instead of 'integer' or 'string'. This fixes 9 instances across the schema.

Fixes #356